### PR TITLE
Remove trailing comma

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,6 @@
 	},	
 	"ignore": [
 		"**/.*",
-		"node_modules",
+		"node_modules"
 	]
 }


### PR DESCRIPTION
Bower(version 1.4.1) fails to install this package because of trailing comma